### PR TITLE
Add support for S3 temperature

### DIFF
--- a/code/components/jomjol_helper/CMakeLists.txt
+++ b/code/components/jomjol_helper/CMakeLists.txt
@@ -2,6 +2,6 @@ FILE(GLOB_RECURSE app_sources ${CMAKE_CURRENT_SOURCE_DIR}/*.*)
 
 idf_component_register(SRCS ${app_sources}
                     INCLUDE_DIRS "."
-                    REQUIRES esp_timer esp-tflite-micro jomjol_logfile fatfs sdmmc vfs)
+                    REQUIRES esp_timer esp-tflite-micro esp_driver_tsens jomjol_logfile fatfs sdmmc vfs)
 
 

--- a/code/components/jomjol_helper/Helper.h
+++ b/code/components/jomjol_helper/Helper.h
@@ -40,6 +40,7 @@ int removeFolder(const char* folderPath, const char* logTag);
 string toLower(string in);
 string toUpper(string in);
 
+void initTemperatureSensor();
 float temperatureRead();
 
 std::string intToHexString(int _valueInt);

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -407,6 +407,10 @@ extern "C" void app_main(void)
     // ********************************************
     setupTime();    // NTP time service: Status of time synchronization will be checked after every round (server_tflite.cpp)
 
+    // Init SOC temperature sensor (if supported by hardware)
+    // ********************************************
+    initTemperatureSensor();
+
     // Set CPU Frequency
     // ********************************************
     setCpuFrequency();


### PR DESCRIPTION
Fixes #4

Based on https://github.com/jomjol/AI-on-the-edge-device/commit/b72d809e59ea98b2ea58314951fabf73b9ed91e7 that was later removed from upstream (for whatever reason).

I just decided to read temperature on-demand instead of in task that runs each 5 seconds.