### PR TITLE
Refuse to save config when config.ini was never loaded (fixes silent config wipe)

### DIFF
--- a/sd-card/html/edit_config_raw.html
+++ b/sd-card/html/edit_config_raw.html
@@ -62,13 +62,20 @@
 
 
 	function LoadConfigNeu() {
-		domainname = getDomainname();  
-		loadConfig(domainname); 	
+		domainname = getDomainname();
+		if (!loadConfig(domainname)) {
+			firework.launch('Configuration could not be loaded! Please reload the page!', 'danger', 30000);
+			return;
+		}
 		document.getElementById("inputTextToSave").value = getConfig();
 		}
 
 	function saveTextAsFile()
 	{
+		if (!config_loaded_ok) {
+			firework.launch('Not saving: the configuration was never loaded from the device. Saving now would overwrite config.ini with defaults. Please reload the page!', 'danger', 30000);
+			return;
+		}
 		FileDeleteOnServer("/config/config.ini", domainname);
 		var textToSave = document.getElementById("inputTextToSave").value;
 		FileSendContent(textToSave, "/config/config.ini", domainname);

--- a/sd-card/html/readconfigcommon.js
+++ b/sd-card/html/readconfigcommon.js
@@ -1,4 +1,9 @@
 function SaveConfigToServer(_domainname){
+     if (!config_loaded_ok) {
+          firework.launch('Not saving: the configuration was never loaded from the device. Saving now would overwrite config.ini with defaults. Please reload the page!', 'danger', 30000);
+          return;
+     }
+
      // leere Zeilen am Ende löschen
      var zw = config_split.length - 1;
 	 
@@ -132,17 +137,30 @@ function getConfig() {
 }
 
      
+// True only after config.ini has actually been fetched. SaveConfigToServer
+// refuses to write while this is false: regenerating config.ini from a page
+// that silently failed to load it wipes the whole device configuration.
+var config_loaded_ok = false;
+
 function loadConfig(_domainname) {
     var xhttp = new XMLHttpRequest();
-    
+
 	try {
-        url = _domainname + '/fileserver/config/config.ini';     
+        url = _domainname + '/fileserver/config/config.ini';
         xhttp.open("GET", url, false);
         xhttp.send();
+
+        if ((xhttp.status != 200) || (xhttp.responseText.trim().length == 0)) {
+            return false;
+        }
+
         config_gesamt = xhttp.responseText;
         config_gesamt = config_gesamt.replace("InitalRotate", "InitialRotate");         // Korrigiere Schreibfehler in config.ini !!!!!
-    } catch (error) {}
-    
+    } catch (error) {
+        return false;
+    }
+
+    config_loaded_ok = true;
 	return true;
 }
 

--- a/sd-card/html/readconfigparam.js
+++ b/sd-card/html/readconfigparam.js
@@ -833,6 +833,11 @@ function isCommented(input) {
 }    
 
 function SaveConfigToServer(_domainname){
+    if (typeof config_loaded_ok !== "undefined" && !config_loaded_ok) {
+        firework.launch('Not saving: the configuration was never loaded from the device. Saving now would overwrite config.ini with defaults. Please reload the page!', 'danger', 30000);
+        return;
+    }
+
     // leere Zeilen am Ende löschen
     var zw = config_split.length - 1;
 	 


### PR DESCRIPTION
Resolves #24

`loadConfig()` fetched `config.ini` with a synchronous XHR inside a `try/catch` that swallowed every failure and returned `true` unconditionally. If the fetch failed (e.g. device mid-OTA-reboot, server busy), every config page rendered pure JS defaults with all sections disabled — and pressing Save regenerated `config.ini` from that empty state, silently wiping the entire device configuration. The next save rotated the gutted file into `config.bak`, destroying the last good copy too. Full analysis in #24.

Changes:

- `readconfigcommon.js`: `loadConfig()` now returns `false` on exception, non-200 status, or empty response body, and sets a `config_loaded_ok` flag on success. This activates the `"Configuration could not be loaded! Please reload the page!"` error paths that every calling page already had in place but that could never trigger.
- `readconfigcommon.js` / `readconfigparam.js`: both `SaveConfigToServer()` implementations refuse to write unless `config_loaded_ok` is set, with a clear error telling the user to reload instead.
- `edit_config_raw.html`: the raw editor now checks the `loadConfig()` result (it previously ignored it) and its `saveTextAsFile()` gets the same guard, since saving an empty textarea has the same destructive effect.

No behaviour change in the happy path. Tested on an AI-on-the-edge-cam (ESP32-S3, OV2640): normal load/save works as before; with the device unreachable at page load, the page now shows the load error and Save is blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)