### PR TITLE
MQTT: keep Home Assistant available during deep sleep (expire_after, not LWT)

### DIFF
--- a/code/components/jomjol_flowcontroll/MainFlowControl.cpp
+++ b/code/components/jomjol_flowcontroll/MainFlowControl.cpp
@@ -38,6 +38,10 @@
 #include "psram.h"
 #include "basic_auth.h"
 
+#ifdef ENABLE_MQTT
+#include "interface_mqtt.h"
+#endif // ENABLE_MQTT
+
 // support IDF 5.x
 #ifndef portTICK_RATE_MS
 #define portTICK_RATE_MS portTICK_PERIOD_MS
@@ -1705,6 +1709,15 @@ void task_autodoFlow(void *pvParameter)
 
                 if (auto_interval > fr_delta_ms) {
                     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Deep sleep for " + std::to_string(auto_interval - fr_delta_ms) + "ms");
+
+#ifdef ENABLE_MQTT
+                    // Gracefully close MQTT before the abrupt power-down so the broker does not
+                    // publish the retained Last Will ("connection lost"). This keeps Home Assistant
+                    // showing the device available (with its last values) throughout the sleep, and
+                    // removes the race between the broker's Will timer and the next wake/reconnect.
+                    // Must run before the peripheral/PHY teardown below, while the network is up.
+                    MQTTPrepareForSleep();
+#endif // ENABLE_MQTT
 
 #if defined(BOARD_ESP32_S3_ALEKSEI)
                     // Battery-powered AI-on-the-edge-cam: kill the W5500 ethernet PHY

--- a/code/components/jomjol_flowcontroll/MainFlowControl.cpp
+++ b/code/components/jomjol_flowcontroll/MainFlowControl.cpp
@@ -40,6 +40,7 @@
 
 #ifdef ENABLE_MQTT
 #include "interface_mqtt.h"
+#include "server_mqtt.h"
 #endif // ENABLE_MQTT
 
 // support IDF 5.x
@@ -1578,6 +1579,13 @@ void task_autodoFlow(void *pvParameter)
     flowctrl.setSleepGraceSeconds(sleep_grace_seconds);
     autostartIsEnabled = flowctrl.getIsAutoStart();
 
+#ifdef ENABLE_MQTT
+    // Deep-sleep devices cannot cleanly close MQTT before power-off, so the broker's Last Will
+    // would flap them "unavailable" every nap. Tell the HA discovery to drop availability_topic
+    // and rely on expire_after instead (see sendHomeAssistantDiscoveryTopic).
+    setMqtt_DeepSleepEnabled(sleep_while_idle);
+#endif
+
 #if defined(BOARD_ESP32_S3_ALEKSEI)
     if (flowctrl.getBatteryEnabled()) {
         Battery_Init();
@@ -1709,15 +1717,6 @@ void task_autodoFlow(void *pvParameter)
 
                 if (auto_interval > fr_delta_ms) {
                     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Deep sleep for " + std::to_string(auto_interval - fr_delta_ms) + "ms");
-
-#ifdef ENABLE_MQTT
-                    // Gracefully close MQTT before the abrupt power-down so the broker does not
-                    // publish the retained Last Will ("connection lost"). This keeps Home Assistant
-                    // showing the device available (with its last values) throughout the sleep, and
-                    // removes the race between the broker's Will timer and the next wake/reconnect.
-                    // Must run before the peripheral/PHY teardown below, while the network is up.
-                    MQTTPrepareForSleep();
-#endif // ENABLE_MQTT
 
 #if defined(BOARD_ESP32_S3_ALEKSEI)
                     // Battery-powered AI-on-the-edge-cam: kill the W5500 ethernet PHY

--- a/code/components/jomjol_mqtt/interface_mqtt.cpp
+++ b/code/components/jomjol_mqtt/interface_mqtt.cpp
@@ -8,8 +8,6 @@
 #endif
 #include "connect_wlan.h"
 #include "mqtt_client.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "ClassLogFile.h"
 #include "MainFlowControl.h"
 #include "StayAwake.h"
@@ -393,27 +391,6 @@ void MQTTdestroy_client(bool _disable = false) {
 
     if (_disable) // Disable MQTT service, avoid restart with MQTTPublish
         mqtt_configOK = false;
-}
-
-void MQTTPrepareForSleep() {
-    /* Call this right before entering deep sleep (see MainFlowControl autoflow loop).
-     *
-     * Deep sleep cuts power abruptly, which looks like an *ungraceful* disconnect to the broker.
-     * Whether Home Assistant then flips to "unavailable" depends on a race between the broker's
-     * keepalive/Last-Will timer and the device's next wake + reconnect - which is why it happens
-     * only sometimes. To make it deterministic we (1) re-publish "connected" retained so the
-     * availability survives the sleep, then (2) send a *clean* MQTT DISCONNECT. Per the MQTT spec
-     * the broker discards the Will on a clean disconnect, so no "connection lost" is published and
-     * HA keeps showing the device available (with its last values) throughout the sleep. A genuine
-     * crash skips this path, so the Will still fires then - real failures are still detected. */
-    if (!mqtt_enabled || !mqtt_initialized || !mqtt_connected || !client) {
-        return;
-    }
-
-    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Preparing MQTT for deep sleep (re-assert availability + clean disconnect)");
-    esp_mqtt_client_publish(client, lwt_topic.c_str(), lwt_connected.c_str(), 0, 1, 1);  // retained, QoS 1
-    vTaskDelay(pdMS_TO_TICKS(500));  // let the publish flush to the broker before tearing down
-    MQTTdestroy_client(false);       // sends a clean DISCONNECT -> broker suppresses the Last Will
 }
 
 bool getMQTTisEnabled() {

--- a/code/components/jomjol_mqtt/interface_mqtt.cpp
+++ b/code/components/jomjol_mqtt/interface_mqtt.cpp
@@ -8,6 +8,8 @@
 #endif
 #include "connect_wlan.h"
 #include "mqtt_client.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "ClassLogFile.h"
 #include "MainFlowControl.h"
 #include "StayAwake.h"
@@ -393,6 +395,27 @@ void MQTTdestroy_client(bool _disable = false) {
         mqtt_configOK = false;
 }
 
+void MQTTPrepareForSleep() {
+    /* Call this right before entering deep sleep (see MainFlowControl autoflow loop).
+     *
+     * Deep sleep cuts power abruptly, which looks like an *ungraceful* disconnect to the broker.
+     * Whether Home Assistant then flips to "unavailable" depends on a race between the broker's
+     * keepalive/Last-Will timer and the device's next wake + reconnect - which is why it happens
+     * only sometimes. To make it deterministic we (1) re-publish "connected" retained so the
+     * availability survives the sleep, then (2) send a *clean* MQTT DISCONNECT. Per the MQTT spec
+     * the broker discards the Will on a clean disconnect, so no "connection lost" is published and
+     * HA keeps showing the device available (with its last values) throughout the sleep. A genuine
+     * crash skips this path, so the Will still fires then - real failures are still detected. */
+    if (!mqtt_enabled || !mqtt_initialized || !mqtt_connected || !client) {
+        return;
+    }
+
+    LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Preparing MQTT for deep sleep (re-assert availability + clean disconnect)");
+    esp_mqtt_client_publish(client, lwt_topic.c_str(), lwt_connected.c_str(), 0, 1, 1);  // retained, QoS 1
+    vTaskDelay(pdMS_TO_TICKS(500));  // let the publish flush to the broker before tearing down
+    MQTTdestroy_client(false);       // sends a clean DISCONNECT -> broker suppresses the Last Will
+}
+
 bool getMQTTisEnabled() {
     return mqtt_enabled;
 }
@@ -490,6 +513,11 @@ bool mqtt_handler_stay_awake(std::string _topic, char* _data, int _data_len)
 void MQTTconnected(){
     if (mqtt_connected) {
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Connected to broker");
+
+        /* Re-assert availability immediately on every (re)connect (retained), so Home Assistant
+         * recovers from a stale "connection lost" within seconds instead of waiting for the next
+         * digitization round to republish it. QoS 0 to stay non-blocking in the event handler. */
+        esp_mqtt_client_publish(client, lwt_topic.c_str(), lwt_connected.c_str(), 0, 0, 1);
         
         if (connectFunktionMap != NULL) {
             for(std::map<std::string, std::function<void()>>::iterator it = connectFunktionMap->begin(); it != connectFunktionMap->end(); ++it) {

--- a/code/components/jomjol_mqtt/interface_mqtt.h
+++ b/code/components/jomjol_mqtt/interface_mqtt.h
@@ -15,6 +15,7 @@ bool MQTT_Configure(std::string _mqttURI, std::string _clientid, std::string _us
                     int _keepalive, bool SetRetainFlag, void *callbackOnConnected);
 int MQTT_Init();
 void MQTTdestroy_client(bool _disable);
+void MQTTPrepareForSleep();   // Call before deep sleep: re-assert availability + clean disconnect (suppresses LWT)
 
 bool MQTTPublish(std::string _key, std::string _content, int qos, bool retained_flag = 1);            // retained Flag as Standart
 

--- a/code/components/jomjol_mqtt/interface_mqtt.h
+++ b/code/components/jomjol_mqtt/interface_mqtt.h
@@ -15,7 +15,6 @@ bool MQTT_Configure(std::string _mqttURI, std::string _clientid, std::string _us
                     int _keepalive, bool SetRetainFlag, void *callbackOnConnected);
 int MQTT_Init();
 void MQTTdestroy_client(bool _disable);
-void MQTTPrepareForSleep();   // Call before deep sleep: re-assert availability + clean disconnect (suppresses LWT)
 
 bool MQTTPublish(std::string _key, std::string _content, int qos, bool retained_flag = 1);            // retained Flag as Standart
 

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -156,9 +156,31 @@ bool sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
 
     if (entityCategory != "") {
         payload += "\"entity_category\": \"" + entityCategory + "\",";
-    } 
+    }
 
-    payload += 
+    /* expire_after: HA flags the entity stale if the device stops reporting (e.g. battery dies
+     * mid-sleep), while still tolerating a single skipped round - e.g. a reading lost to poor
+     * WiFi. Sized at 2x the digitization interval (one skipped poll) + 120s for wake/connect/
+     * processing jitter.
+     *
+     * Only applied to topics with a predictable per-round cadence:
+     *   - system telemetry (uptime/freeMem/wifiRSSI/CPUtemp) and battery_* are published
+     *     unconditionally every round, so they are reliable liveness indicators;
+     *   - "value" is the user-facing reading; it is published only when a result exists, so a
+     *     sustained absence legitimately means "no fresh reading" and SHOULD go stale.
+     * Excluded: static topics (IP/MAC/firmware/hostname/interval) are sent once and would expire
+     * incorrectly; raw, error, rate and timestamp are published only when non-empty so would
+     * expire on any round a meter omits them; the button/switch controls have no periodic state. */
+    bool perRoundTelemetry =
+        (field == "value" ||
+         field == "uptime" || field == "freeMem" || field == "wifiRSSI" || field == "CPUtemp" ||
+         field == "battery_voltage" || field == "battery_percent");
+    if (perRoundTelemetry && roundInterval > 0) {
+        int expireAfter = (int)(roundInterval * 60.0 * 2) + 120;
+        payload += "\"expire_after\": " + std::to_string(expireAfter) + ",";
+    }
+
+    payload +=
         "\"availability_topic\": \"~/" + std::string(LWT_TOPIC) + "\","  +
         "\"payload_available\": \"" + LWT_CONNECTED + "\","  +
         "\"payload_not_available\": \"" + LWT_DISCONNECTED + "\",";

--- a/code/components/jomjol_mqtt/server_mqtt.cpp
+++ b/code/components/jomjol_mqtt/server_mqtt.cpp
@@ -37,6 +37,7 @@ std::string rateUnit = "Unit/Minute";
 float roundInterval; // Minutes
 int keepAlive = 0; // Seconds
 bool retainFlag;
+bool deepSleepEnabled = false; // SleepWhileIdle: omit LWT availability_topic, rely on expire_after (see sendHomeAssistantDiscoveryTopic)
 static std::string maintopic, domoticzintopic;
 bool sendingOf_DiscoveryAndStaticTopics_scheduled = true; // Set it to true to make sure it gets sent at least once after startup
 
@@ -180,10 +181,17 @@ bool sendHomeAssistantDiscoveryTopic(std::string group, std::string field,
         payload += "\"expire_after\": " + std::to_string(expireAfter) + ",";
     }
 
-    payload +=
-        "\"availability_topic\": \"~/" + std::string(LWT_TOPIC) + "\","  +
-        "\"payload_available\": \"" + LWT_CONNECTED + "\","  +
-        "\"payload_not_available\": \"" + LWT_DISCONNECTED + "\",";
+    /* Availability: an always-on device's retained Last Will on <maintopic>/connection cleanly
+     * signals offline. But a deep-sleep device severs the link ungracefully every nap (it cannot
+     * reliably get a DISCONNECT out before power-off), so the Will fires and HA would show it
+     * unavailable mid-sleep. In sleep mode we OMIT availability_topic and let expire_after (above)
+     * judge liveness by data freshness instead. */
+    if (!deepSleepEnabled) {
+        payload +=
+            "\"availability_topic\": \"~/" + std::string(LWT_TOPIC) + "\","  +
+            "\"payload_available\": \"" + LWT_CONNECTED + "\","  +
+            "\"payload_not_available\": \"" + LWT_DISCONNECTED + "\",";
+    }
 
     payload += string("\"device\": {")  +
         "\"identifiers\": [\"" + maintopic + "\"],"  +
@@ -431,6 +439,10 @@ void SetHomeassistantDiscoveryEnabled(bool enabled) {
 
 void setMqtt_Server_Retain(bool _retainFlag) {
     retainFlag = _retainFlag;
+}
+
+void setMqtt_DeepSleepEnabled(bool _enabled) {
+    deepSleepEnabled = _enabled;
 }
 
 void mqttServer_setMainTopic( std::string _maintopic) {

--- a/code/components/jomjol_mqtt/server_mqtt.h
+++ b/code/components/jomjol_mqtt/server_mqtt.h
@@ -11,6 +11,7 @@ void SetHomeassistantDiscoveryEnabled(bool enabled);
 void mqttServer_setParameter(std::vector<NumberPost*>* _NUMBERS, int interval, float roundInterval);
 void mqttServer_setMeterType(std::string meterType, std::string valueUnit, std::string timeUnit,std::string rateUnit);
 void setMqtt_Server_Retain(bool SetRetainFlag);
+void setMqtt_DeepSleepEnabled(bool enabled);
 void mqttServer_setMainTopic( std::string maintopic);
 void mqttServer_setDmoticzInTopic( std::string domoticzintopic);
 


### PR DESCRIPTION
## Problem
On `SleepWhileIdle` (deep-sleep) builds, Home Assistant intermittently shows the device as **unavailable** while it is asleep, even though the last sensor values are still displayed. Closes #26.

## Root cause
HA availability is driven by the retained MQTT Last Will on `<maintopic>/connection`. Deep sleep severs the connection ungracefully (the chip powers down without a clean DISCONNECT), so once the broker's keepalive lapses it publishes the Will (`connection lost`) and HA marks the device unavailable mid-sleep. Whether the Will fires before the next wake + reconnect is a race, hence the intermittent behaviour. A clean DISCONNECT before sleep isn't reliable either — a deep-sleep device can't get the packet onto the wire before power-off.

## Fix
When `SleepWhileIdle` is enabled, stop keying HA availability off the broker's Will and judge liveness by data freshness instead:

- **Omit `availability_topic`** from the Homeassistant discovery (gated by `setMqtt_DeepSleepEnabled`, set during the autoflow setup) so HA no longer reacts to the Will.
- **Add `expire_after`** (2x interval + 120s) to `value` and the per-round telemetry (uptime / free memory / Wi-Fi RSSI / CPU temp / battery), so an entity only goes stale if the device genuinely stops reporting — while tolerating a single missed poll (e.g. a reading lost to poor Wi-Fi).
- Always-on devices are unaffected: the flag is false for them, so they keep normal LWT-based availability.
- Also re-asserts `connected` on every (re)connect, which speeds availability recovery for always-on devices.

## Hardware verification
Flashed to a live ESP32-S3 battery device running `SleepWhileIdle`. Before: the LWT-driven availability flapped to `unavailable` on every sleep. After: it holds state across sleep/wake cycles and all sensors stay available with their last values. Confirmed via Home Assistant entity history at the exact flash boundary.

Note: this PR has two commits — the first attempted a clean-disconnect-before-sleep, the second replaces it with the approach above (the net file diff is clean). Fine to squash on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
