### PR TITLE
Fix Stay-Awake override swallowing manual /flow_start

### DIFF
--- a/code/components/jomjol_flowcontroll/MainFlowControl.cpp
+++ b/code/components/jomjol_flowcontroll/MainFlowControl.cpp
@@ -55,6 +55,12 @@ long auto_interval = 0;
 bool sleep_while_idle = false;
 int sleep_grace_seconds = 10;
 bool autostartIsEnabled = false;
+// Set by handler_flow_start() so a manual round runs promptly even while the
+// Stay-Awake idle loop is active. That loop waits in repeated short vTaskDelay
+// chunks, which re-arm after the xTaskAbortDelay that normally services
+// /flow_start -- swallowing the manual trigger until the whole AutoTimer
+// interval elapses. See allexoK#28.
+volatile bool manualFlowStartRequested = false;
 
 int countRounds = 0;
 bool isPlannedReboot = false;
@@ -285,6 +291,7 @@ esp_err_t handler_flow_start(httpd_req_t *req)
 
     if (autostartIsEnabled)
     {
+        manualFlowStartRequested = true;         // break the Stay-Awake idle loop too (allexoK#28), not just the single vTaskDelay
         xTaskAbortDelay(xHandletask_autodoFlow); // Delay will be aborted if task is in blocked (waiting) state. If task is already running, no action
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flow start triggered by REST API /flow_start");
         const char *resp_str = "The flow is going to be started immediately or is already running";
@@ -314,6 +321,7 @@ esp_err_t MQTTCtrlFlowStart(std::string _topic)
 
     if (autostartIsEnabled)
     {
+        manualFlowStartRequested = true;         // break the Stay-Awake idle loop too (allexoK#28), not just the single vTaskDelay
         xTaskAbortDelay(xHandletask_autodoFlow); // Delay will be aborted if task is in blocked (waiting) state. If task is already running, no action
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "Flow start triggered by MQTT topic " + _topic);
     }
@@ -1600,6 +1608,7 @@ void task_autodoFlow(void *pvParameter)
 
     while (autostartIsEnabled)
     {
+        manualFlowStartRequested = false; // consumed: a (manual or scheduled) round is now starting
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "----------------------------------------------------------------"); // Clear separation between runs
         time_t roundStartTime = getUpTime();
 
@@ -1693,7 +1702,7 @@ void task_autodoFlow(void *pvParameter)
                 // sleep immediately instead of staying awake until the next round.
                 bool announced_stay_awake = false;
                 fr_delta_ms = (esp_timer_get_time() - fr_start) / 1000;
-                while ((auto_interval > fr_delta_ms) && StayAwake_Get()) {
+                while ((auto_interval > fr_delta_ms) && StayAwake_Get() && !manualFlowStartRequested) {
                     if (!announced_stay_awake) {
                         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Stay-Awake override is on -- skipping deep sleep");
                         announced_stay_awake = true;
@@ -1703,7 +1712,7 @@ void task_autodoFlow(void *pvParameter)
                     fr_delta_ms = (esp_timer_get_time() - fr_start) / 1000;
                 }
 
-                if (auto_interval > fr_delta_ms) {
+                if (auto_interval > fr_delta_ms && !manualFlowStartRequested) {
                     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Deep sleep for " + std::to_string(auto_interval - fr_delta_ms) + "ms");
 
 #if defined(BOARD_ESP32_S3_ALEKSEI)


### PR DESCRIPTION
Fixes #28

## Problem

While the **Stay-Awake override** is active, a manual round trigger — `GET /flow_start`, the web UI "start round" button, or the MQTT flow-start control — is silently ignored. No round runs until the full `[AutoTimer] Interval` elapses (e.g. 30 minutes). A reboot appears to "fix" it because boot runs a round before the wait loop is entered.

This defeats the main purpose of Stay-Awake (keeping a deep-sleep/battery unit responsive for interactive reconfiguration and tuning): you enable it precisely so you can trigger rounds and see the effect of changes, but the triggers do nothing.

## Root cause

`/flow_start` (and `MQTTCtrlFlowStart`) don't run a round directly — they call `xTaskAbortDelay(xHandletask_autodoFlow)` to abort the flow task's blocking `vTaskDelay` so the loop falls through and runs the next round.

That works in the normal idle path (a single `vTaskDelay(remaining interval)`). But the Stay-Awake path waits in a **loop of repeated 10-second chunks**:

```c
while ((auto_interval > fr_delta_ms) && StayAwake_Get()) {
    ...
    vTaskDelay(((remaining_ms < 10000) ? remaining_ms : 10000) / portTICK_PERIOD_MS);
    fr_delta_ms = (esp_timer_get_time() - fr_start) / 1000;
}
```

`xTaskAbortDelay` aborts only the *current* chunk; the `while` condition still holds, so the loop immediately re-arms another 10 s delay and the trigger is swallowed.

## Fix

- Add a `volatile bool manualFlowStartRequested` flag.
- Set it in **both** manual entry points: `handler_flow_start()` (REST) and `MQTTCtrlFlowStart()` (MQTT), alongside the existing `xTaskAbortDelay`.
- Honor it in the Stay-Awake loop condition: `while (... && StayAwake_Get() && !manualFlowStartRequested)`.
- Guard the deep-sleep branch with `&& !manualFlowStartRequested` so breaking out early to service a manual round doesn't fall straight into `esp_deep_sleep_start()`.
- Clear the flag at the top of each round iteration (so it's one-shot per round; scheduled rounds and the normal deep-sleep path are unaffected).

Net change is small and contained to `MainFlowControl.cpp`.

## Behaviour after fix

- Stay-Awake on + `/flow_start` → round runs promptly (no longer waits out the interval).
- Stay-Awake on, no manual trigger → unchanged (idles until the interval elapses).
- Stay-Awake off → unchanged (deep sleep still fires normally).

## Testing

Reproduced on an `esp32s3-test` build (`Interval = 30`, `SleepWhileIdle = true`, Stay-Awake on): `/flow_start` left `/json` `timestamp` frozen for >90 s. Change is verified by inspection of the loop logic; on-hardware confirmation via OTA to follow.

A cleaner long-term approach would replace the chunked polling with a notification-based wait (`ulTaskNotifyTake(timeout)` + `xTaskNotifyGive` from the flow-start handlers); this PR keeps the change minimal and low-risk.
