### PR TITLE
Unmount SD card before deep sleep to prevent FAT corruption

### DIFF
--- a/code/components/jomjol_flowcontroll/MainFlowControl.cpp
+++ b/code/components/jomjol_flowcontroll/MainFlowControl.cpp
@@ -6,6 +6,8 @@
 #include "esp_log.h"
 #include <esp_timer.h>
 #include <esp_sleep.h>
+#include "esp_idf_version.h"
+#include "sdcard_init.h"
 #include "driver/gpio.h"
 #if defined(BOARD_ESP32_S3_ALEKSEI)
 #include "driver/rtc_io.h"
@@ -1705,6 +1707,21 @@ void task_autodoFlow(void *pvParameter)
 
                 if (auto_interval > fr_delta_ms) {
                     LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Deep sleep for " + std::to_string(auto_interval - fr_delta_ms) + "ms");
+
+                    // Cleanly unmount the SD card before sleeping. Deep sleep cuts
+                    // the SD power rail on battery boards (PER_ENABLE, below) and a
+                    // cold boot remounts from scratch -- so the volume must be left
+                    // consistent first. Unmounting flushes the FATFS window, FAT
+                    // table and FSINFO sector; without it an interrupted FAT
+                    // metadata write corrupts the filesystem (observed as cards that
+                    // revert to the "missing config.ini" emergency AP and then fail
+                    // to mount at all). This must be the last SD access before sleep.
+                    // Gated on the same IDF version as the mount call in main.cpp.
+#if (ESP_IDF_VERSION <= ESP_IDF_VERSION_VAL(5, 1, 2))
+                    esp_vfs_fat_sdmmc_unmount_mh();
+#else
+                    esp_vfs_fat_sdmmc_unmount();
+#endif
 
 #if defined(BOARD_ESP32_S3_ALEKSEI)
                     // Battery-powered AI-on-the-edge-cam: kill the W5500 ethernet PHY

--- a/code/components/jomjol_helper/sdcard_init.h
+++ b/code/components/jomjol_helper/sdcard_init.h
@@ -96,6 +96,27 @@ esp_err_t esp_vfs_fat_sdmmc_mount_mh(const char* base_path, const sdmmc_host_t* 
  */
 esp_err_t esp_vfs_fat_sdspi_mount_mh(const char* base_path, const sdmmc_host_t* host_config_input, const sdspi_device_config_t* slot_config, const esp_vfs_fat_mount_config_t* mount_config, sdmmc_card_t** out_card);
 
+/**
+ * @brief Unmount the single SD card mounted via esp_vfs_fat_sdmmc_mount_mh().
+ *
+ * Counterpart to esp_vfs_fat_sdmmc_mount_mh(). Flushes the FATFS window, FAT
+ * table and FSINFO sector, then unregisters the volume and deinitialises the
+ * host. Call this before removing power from the card (e.g. before deep sleep
+ * on battery boards that gate the SD rail) to avoid filesystem corruption.
+ *
+ * @return ESP_OK on success, or an error code from the FATFS / VFS layers.
+ */
+esp_err_t esp_vfs_fat_sdmmc_unmount_mh(void);
+
+/**
+ * @brief Unmount a specific SD card mounted via esp_vfs_fat_sdmmc_mount_mh().
+ *
+ * @param base_path  path where the partition was registered (e.g. "/sdcard")
+ * @param card       card handle returned by the mount call
+ * @return ESP_OK on success, ESP_ERR_INVALID_ARG if the card is not mounted.
+ */
+esp_err_t esp_vfs_fat_sdcard_unmount_mh(const char *base_path, sdmmc_card_t *card);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Fixes #30

## Problem

The deep-sleep path in `task_autodoFlow()` never unmounts the SD card before sleeping. On battery boards (`BOARD_ESP32_S3_ALEKSEI`) the very next lines cut the SD power rail (`PER_ENABLE`), and a cold boot remounts from scratch — so any FAT metadata write still buffered by FATFS is interrupted by power removal. FAT has no journaling, so repeated unclean power-downs corrupt the filesystem.

Observed in the field as a unit that dropped **both `config.ini` and `wlan.ini` at once**, booted into the "missing config.ini" emergency AP, and left the card **unreadable even in a PC** — i.e. corrupted FAT/directory metadata, not worn flash (it happened to a brand-new card within a week).

## Fix

Cleanly unmount the card immediately before sleeping, as the **last SD access**, so FATFS flushes its window, FAT table and FSINFO sector and the volume is left consistent when the rail drops.

- The unmount is gated on the **same `ESP_IDF_VERSION` check the mount uses** in `main.cpp`, so it pairs with whichever mount variant was used:
  - `esp_vfs_fat_sdmmc_unmount_mh()` for IDF ≤ 5.1.2
  - stock `esp_vfs_fat_sdmmc_unmount()` otherwise
- `esp_vfs_fat_sdmmc_unmount_mh()` (and `esp_vfs_fat_sdcard_unmount_mh()`) were already defined in `sdcard_init.c` but never declared in `sdcard_init.h`; this PR exposes them.

Net change is small: a gated unmount call plus two header declarations. Only the single deep-sleep entry point is affected; the non-deep-sleep idle path (`vTaskDelay`) is untouched and keeps the card mounted for the next round.

## Behaviour after fix

- Deep sleep → card flushed and unmounted, then rail cut → no in-flight FAT write at power-off.
- Cold boot → mounts cleanly as before.
- Stay-Awake / `vTaskDelay` idle path → unchanged (card stays mounted).

## Testing

Builds for the `esp32s3-test` battery target. Verified by inspection of the sleep path; on-hardware OTA soak on the live battery unit to follow (the very unit that lost the two cards).

A complementary hardening step (not in this PR) would be to close the still-open log append handle before unmount, though `f_mount(0)` already flushes the volume.
