### PR TITLE
Protect config.ini from total loss on interrupted save/migration

### DIFF
--- a/code/components/jomjol_fileserver_ota/server_file.cpp
+++ b/code/components/jomjol_fileserver_ota/server_file.cpp
@@ -874,8 +874,20 @@ static esp_err_t delete_post_handler(httpd_req_t *req)
             LogFile.WriteToFile(ESP_LOG_INFO, TAG, "File does not exist: " + string(filename));
         }
 
-        /* Delete file */
-        unlink(filepath);
+        /* Delete file -- but never leave config.ini with no copy on disk. The
+         * web "Save" deletes config.ini and then uploads a fresh one; if that
+         * upload never lands durably (Wi-Fi drop, reboot, crash) the device
+         * would otherwise boot with no config and fall into the setup AP.
+         * Preserve the current config as the backup instead of deleting it; it
+         * is auto-restored on the next boot if the new upload never arrives. */
+        if (strcmp(filepath, CONFIG_FILE) == 0) {
+            DeleteFile(CONFIG_FILE_BACKUP); // free the rename target (FATFS won't overwrite)
+            RenameFile(CONFIG_FILE, CONFIG_FILE_BACKUP);
+            LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "config.ini preserved as backup before re-upload");
+        }
+        else {
+            unlink(filepath);
+        }
         LogFile.WriteToFile(ESP_LOG_DEBUG, TAG, "File deleted: " + string(filename));
         ESP_LOGI(TAG, "File deletion completed");
 

--- a/code/main/main.cpp
+++ b/code/main/main.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <vector>
 #include <regex>
+#include <unistd.h>
 
 #include "esp_psram.h"
 #include "esp_pm.h"
@@ -95,6 +96,7 @@ extern std::string getHTMLcommit(void);
 
 std::vector<std::string> splitString(const std::string& str);
 void migrateConfiguration(void);
+void restoreConfigFromBackupIfMissing(void);
 bool setCpuFrequency(void);
 
 static const char *TAG = "MAIN";
@@ -419,6 +421,13 @@ extern "C" void app_main(void)
         }
     }
 
+    // Restore config.ini from its backup if a previous save or migration was
+    // interrupted (Wi-Fi drop, power loss, crash) and left it missing. Runs
+    // before the AP-mode check below so the device self-heals instead of
+    // dropping into setup mode with the user's whole configuration gone.
+    // ********************************************
+    restoreConfigFromBackupIfMissing();
+
     // Migrate parameter in config.ini to new naming (firmware 15.0 and newer)
     // ********************************************
     migrateConfiguration();
@@ -623,6 +632,23 @@ extern "C" void app_main(void)
     }
     else { // Any other error is critical and makes running the flow impossible. Init is going to abort.
         LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Initialization failed. Flow task start aborted. Loading reduced web interface...");
+    }
+}
+
+void restoreConfigFromBackupIfMissing(void) {
+    if (FileExists(CONFIG_FILE)) {
+        return; // config.ini present -- nothing to do
+    }
+
+    if (!FileExists(CONFIG_FILE_BACKUP)) {
+        return; // no backup to restore from
+    }
+
+    if (RenameFile(CONFIG_FILE_BACKUP, CONFIG_FILE)) {
+        LogFile.WriteToFile(ESP_LOG_WARN, TAG, "config.ini was missing -- restored it from " + std::string(CONFIG_FILE_BACKUP));
+    }
+    else {
+        LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "config.ini missing and restore from " + std::string(CONFIG_FILE_BACKUP) + " failed");
     }
 }
 
@@ -946,13 +972,23 @@ void migrateConfiguration(void) {
     }
 
     if (migrated) {
-        // At least one replacement happened
+        // At least one replacement happened. Move the current config aside as
+        // the backup, then write the migrated version. DeleteFile() first so the
+        // rename has a free target (FATFS rename does not overwrite).
+        DeleteFile(CONFIG_FILE_BACKUP);
         if (!RenameFile(CONFIG_FILE, CONFIG_FILE_BACKUP)) {
             LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to create backup of Config file!");
             return;
         }
 
         FILE *pfile = fopen(CONFIG_FILE, "w");
+        if (!pfile) {
+            // Opening the new config failed after the old one was moved aside.
+            // Restore the backup so we never leave the device with no config.
+            LogFile.WriteToFile(ESP_LOG_ERROR, TAG, "Failed to open config for writing during migration -- restoring backup");
+            RenameFile(CONFIG_FILE_BACKUP, CONFIG_FILE);
+            return;
+        }
 
         for (int i = 0; i < configLines.size(); i++) {
             if (!isInString(configLines[i], ";UNUSED_PARAMETER")) {
@@ -961,6 +997,8 @@ void migrateConfiguration(void) {
             }
         }
 
+        fflush(pfile);
+        fsync(fileno(pfile)); // make the migrated config durable before any later sleep/reset
         fclose(pfile);
         LogFile.WriteToFile(ESP_LOG_INFO, TAG, "Config file migrated. Saved backup to " + string(CONFIG_FILE_BACKUP));
     }


### PR DESCRIPTION
Fixes #32

## Problem

`config.ini` can be lost completely — card left with **no `config.ini` and no backup** — if a config save or the boot migration is interrupted. Since the setup-AP fallback triggers when `config.ini` **or** `wlan.ini` is missing, losing `config.ini` alone bricks the device into the "missing config.ini" emergency AP even though `wlan.ini` is intact, taking the whole configuration with it.

Two reachable paths:

1. **Web "Save"** — the upload handler refuses to overwrite, so the UI deletes `config.ini` then uploads a fresh copy. The delete handler protected only `wlan.ini` and `unlink`ed `config.ini`; the upload handler also `unlink`s the partial file on a recv/write error. On a weak-signal/battery unit, *delete → upload drops mid-transfer* leaves nothing.
2. **Boot migration** — `migrateConfiguration()` renames `config.ini` to backup, then `fopen(..., "w")` with no NULL check and no `fsync`; a failed open after the rename, or a power cut before flush, loses it.

Observed in the field on a battery unit: setup AP, readable card, `wlan.ini` present, `config.ini` + `config.bak` both gone, stale `reboot.txt` in root.

## Fix (firmware only — no web/JS changes)

- **Delete handler:** when the target is the live `config.ini`, preserve it as `config.bak` (rename) instead of `unlink`, so the Save flow always leaves a recoverable copy.
- **Boot:** `restoreConfigFromBackupIfMissing()` restores `config.ini` from `config.bak` when missing, run **before** the AP-mode check so the device self-heals.
- **Migration:** delete the stale backup before renaming (FATFS rename won't overwrite), NULL-check `fopen` and restore the backup on failure, and `fflush`+`fsync` before close.

Net result: `config.ini` cannot be left missing without a `config.bak` to restore from, and the device recovers automatically on the next boot rather than dropping into setup mode.

## Behaviour after fix

- Save interrupted (Wi-Fi drop / reboot mid-upload) → old config survives as `config.bak`, restored on next boot.
- Migration `fopen` fails → backup restored, no data loss.
- Normal save → `config.ini` written, previous version retained as `config.bak`.
- First-flash empty card (no config, no backup) → unchanged: setup AP as intended.

## Testing

Builds for `esp32s3-test`. Verified by inspection of the save/delete/boot paths; on-hardware confirmation to follow. Complements #31 (SD unmount before deep sleep) — both protect critical files from interrupted writes.
